### PR TITLE
Hardening Firebase Rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -7,7 +7,6 @@
     },
     "admins": {
       ".indexOn": "email",
-      ".write": true,
       ".read": "root.child('admins/'+auth.uid).exists() && root.child('admins/'+auth.uid).child('role').val().matches(/(admin)/)",
       "$uid": {
         ".read": "$uid == auth.uid || root.child('admins/'+auth.uid).exists() || data.child('email').val() == auth.email",
@@ -54,10 +53,7 @@
     "products": {
       ".read": true,
       ".write": "root.child('admins/'+auth.uid).exists() && root.child('admins/'+auth.uid).child('role').val().matches(/(admin)/)",
-      ".indexOn": ["published", "category", "rdateUpdated", "url"],
-      "$p_id": {
-        ".read": "data.child('published').val() == true || root.child('admins/'+auth.uid).exists()"
-      }
+      ".indexOn": ["published", "category", "rdateUpdated", "url"]
     },
     "posts": {
       ".read": true,
@@ -66,7 +62,6 @@
     },
     "users": {
       ".read": "root.child('admins/'+auth.uid).exists() && root.child('admins/'+auth.uid).child('role').val().matches(/(admin)/)",
-      ".write": true,
       "$uid": {
         ".read": "$uid == auth.uid || root.child('admins/'+auth.uid).exists()",
         ".write": "$uid == auth.uid || root.child('admins/'+auth.uid).exists()"


### PR DESCRIPTION
Fixes #17
You can view the security issues in [this report](https://noless.io/report/-L7-_vTY7hdI4RSIBJ6d/5c5aafcb-5a25-4e32-b5c7-b913b957de76).

## Solution

I removed the rule `".write": true` from `admins` and `users`.
In addition, I removed the read rule from `"/products/$p_id"`, since it was useless because of the `".read": true` under `products`.


Please tell me if there is a problem with reading all the products.

An analysis on the fixed rules can be [seen here](https://noless.io/report/-L7KsunxzDfHeWptnl1J/4da8e97b-fdf0-463c-a51a-13ffc9acfd9a).